### PR TITLE
add slice length validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,3 @@ install:
 script:
   - go test -v -cover -covermode=count -coverprofile=cover.prof
   - cat cover.prof
-  - goveralls -coverprofile cover.prof -repotoken $COVERALLS_TOKEN

--- a/jsonmap_test.go
+++ b/jsonmap_test.go
@@ -544,7 +544,7 @@ func TestValidateOuterRangeSliceThingOverMax(t *testing.T) {
 }
 
 func TestValidateOuterRangeSliceThingInRange(t *testing.T) {
-	v := &OuterMinSliceThing{}
+	v := &OuterRangeSliceThing{}
 	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_things": [{"foo": "fooz"}, {"foo": "fooz2"}]}`), v)
 	if err != nil {
 		t.Fatal(err)

--- a/jsonmap_test.go
+++ b/jsonmap_test.go
@@ -38,6 +38,18 @@ type OuterSliceThing struct {
 	InnerThings []InnerThing
 }
 
+type OuterMaxSliceThing struct {
+	InnerThings []InnerThing
+}
+
+type OuterMinSliceThing struct {
+	InnerThings []InnerThing
+}
+
+type OuterRangeSliceThing struct {
+	InnerThings []InnerThing
+}
+
 type OuterPointerSliceThing struct {
 	InnerThings []*InnerThing
 }
@@ -170,6 +182,39 @@ var OuterSliceThingTypeMap = StructMap{
 			StructFieldName: "InnerThings",
 			JSONFieldName:   "inner_things",
 			Contains:        SliceOf(InnerThingTypeMap),
+		},
+	},
+}
+
+var ContainsMaxSliceSizeTypeMap = StructMap{
+	OuterMaxSliceThing{},
+	[]MappedField{
+		{
+			StructFieldName: "InnerThings",
+			JSONFieldName:   "inner_things",
+			Contains:        SliceOfMax(InnerThingTypeMap, 2),
+		},
+	},
+}
+
+var ContainsMinSliceSizeTypeMap = StructMap{
+	OuterMinSliceThing{},
+	[]MappedField{
+		{
+			StructFieldName: "InnerThings",
+			JSONFieldName:   "inner_things",
+			Contains:        SliceOfMin(InnerThingTypeMap, 2),
+		},
+	},
+}
+
+var ContainsRangeSliceSizeTypeMap = StructMap{
+	OuterRangeSliceThing{},
+	[]MappedField{
+		{
+			StructFieldName: "InnerThings",
+			JSONFieldName:   "inner_things",
+			Contains:        SliceOfRange(InnerThingTypeMap, 1, 2),
 		},
 	},
 }
@@ -361,6 +406,9 @@ var TestTypeMapper = NewTypeMapper(
 	OuterPointerThingTypeMap,
 	OuterInterfaceThingTypeMap,
 	OuterSliceThingTypeMap,
+	ContainsMaxSliceSizeTypeMap,
+	ContainsMinSliceSizeTypeMap,
+	ContainsRangeSliceSizeTypeMap,
 	OuterPointerSliceThingTypeMap,
 	OuterPointerToSliceThingTypeMap,
 	OuterVariableThingTypeMap,
@@ -432,6 +480,74 @@ func TestValidateOuterSliceThingNotAList(t *testing.T) {
 	}
 	if err.Error() != "validation error: 'inner_things': expected a list" {
 		t.Fatal("Unexpected error message:", err.Error())
+	}
+}
+
+func TestValidateOuterSliceThingOverMax(t *testing.T) {
+	v := &OuterMaxSliceThing{}
+	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_things": [{"foo": "fooz"}, {"foo": "fooz2"}, {"foo": "fooz3"}]}`), v)
+	if err == nil {
+		t.Fatal("Unexpected success")
+	}
+	if err.Error() != "validation error: 'inner_things': must have at most 2 elements" {
+		t.Fatal("Unexpected error message:", err.Error())
+	}
+}
+
+func TestValidateOuterSliceThingUnderMax(t *testing.T) {
+	v := &OuterMaxSliceThing{}
+	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_things": [{"foo": "fooz"}, {"foo": "fooz2"}]}`), v)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateOuterSliceThingUnderMin(t *testing.T) {
+	v := &OuterMinSliceThing{}
+	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_things": [{"foo": "fooz"}]}`), v)
+	if err == nil {
+		t.Fatal("Unexpected success")
+	}
+	if err.Error() != "validation error: 'inner_things': must have at least 2 elements" {
+		t.Fatal("Unexpected error message:", err.Error())
+	}
+}
+
+func TestValidateOuterSliceThingOverMin(t *testing.T) {
+	v := &OuterMinSliceThing{}
+	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_things": [{"foo": "fooz"}, {"foo": "fooz2"}]}`), v)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateOuterRangeSliceThingUnderMin(t *testing.T) {
+	v := &OuterRangeSliceThing{}
+	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_things": []}`), v)
+	if err == nil {
+		t.Fatal("Unexpected success")
+	}
+	if err.Error() != "validation error: 'inner_things': must have between 1 and 2 elements" {
+		t.Fatal("Unexpected error message:", err.Error())
+	}
+}
+
+func TestValidateOuterRangeSliceThingOverMax(t *testing.T) {
+	v := &OuterRangeSliceThing{}
+	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_things": [{"foo": "fooz"}, {"foo": "fooz2"}, {"foo": "fooz3"}]}`), v)
+	if err == nil {
+		t.Fatal("Unexpected success")
+	}
+	if err.Error() != "validation error: 'inner_things': must have between 1 and 2 elements" {
+		t.Fatal("Unexpected error message:", err.Error())
+	}
+}
+
+func TestValidateOuterRangeSliceThingInRange(t *testing.T) {
+	v := &OuterMinSliceThing{}
+	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_things": [{"foo": "fooz"}, {"foo": "fooz2"}]}`), v)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Add length validation of a slice. The following new functions have the same behavior as `SliceOf` with additional validation:
- SliceOfRange - slice has a length between the provided upper and lower bound (inclusive)
- SliceOfMin - slice has a length ≥ the provided lower bound 
- SliceOfMax - slice has a length ≤ the provided upper bound