### PR TITLE
return multiple validation errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - 1.4
+  - 1.12.5
   - tip
 install:
   - go get -t ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/russellhaering/jsonmap
+
+go 1.12
+
+require (
+	github.com/rnd42/go-jsonpointer v0.0.0-20140520035338-0480215403db
+	github.com/stretchr/testify v1.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rnd42/go-jsonpointer v0.0.0-20140520035338-0480215403db h1:Ug0ysRQpfI+bQYuPXeIknWZLAQ9Trh75K20vG2Ry1Lw=
+github.com/rnd42/go-jsonpointer v0.0.0-20140520035338-0480215403db/go.mod h1:L6fTQDE8ROasK8aBmd1dHwbX89WSEQpLd0ASF9fhtq8=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/jsonmap.go
+++ b/jsonmap.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/rnd42/go-jsonpointer"
 	"reflect"
+	"strconv"
+	"strings"
 	"text/template"
 	"time"
 )
@@ -18,32 +21,96 @@ var (
 	nullRawMessage = RawMessage{nullJSONValue}
 )
 
-type ValidationError struct {
-	reason string
-	rpath  []string
+type FlattenedPathError struct {
+	Path string
+	Message string
 }
 
-func NewValidationError(reason string, a ...interface{}) *ValidationError {
-	return &ValidationError{
-		reason: fmt.Sprintf(reason, a...),
-		rpath:  make([]string, 0, 2),
+func (e *FlattenedPathError) String() string {
+	return fmt.Sprintf("%s: %s\n", e.Path, e.Message)
+}
+
+func NewFlattedPathError(path, message string) *FlattenedPathError {
+	return &FlattenedPathError{
+		Path: path,
+		Message: message,
 	}
+}
+
+type ValidationError struct {
+	NestedErrors []*FlattenedPathError
 }
 
 func (e *ValidationError) Error() string {
-	msg := e.reason
-	for _, seg := range e.rpath {
-		msg = seg + ": " + msg
+	b := strings.Builder{}
+	b.WriteString("Validation Errors: \n")
+	for _, f := range e.NestedErrors {
+		b.WriteString(f.String())
 	}
-	return "validation error: " + msg
+	return b.String()
 }
 
-func (e *ValidationError) PushIndex(idx int) {
-	e.rpath = append(e.rpath, fmt.Sprintf("index %d", idx))
+func (e *ValidationError) AddError(err *FieldError, path ...string)  {
+	path = append(path, err.Field)
+	pointer := jsonpointer.NewJSONPointerFromTokens(&path)
+	if err.Message != "" {
+		jsonpath := pointer.String()
+		e.NestedErrors = append(e.NestedErrors, NewFlattedPathError(jsonpath, err.Message))
+	}
+	for _, v := range err.FieldErrors {
+		e.AddError(v, path...)
+	}
 }
 
-func (e *ValidationError) PushKey(key string) {
-	e.rpath = append(e.rpath, fmt.Sprintf("'%s'", key))
+type FieldError struct {
+	Field string
+	Message string
+	FieldErrors []*FieldError
+}
+
+func (e *FieldError) ErrorMessage() string {
+	if e.Field != "" && e.Message != "" {
+		return fmt.Sprintf("%s: %s\n", e.Field, e.Message)
+	}
+	return e.Message
+}
+
+func (e *FieldError) Error() string {
+	prefix := e.Field
+	msg := e.ErrorMessage()
+	for _, f := range e.FieldErrors {
+		msg += prefix + f.ErrorMessage()
+	}
+	return msg
+}
+
+func (e *FieldError) AddError(err *FieldError)  {
+	e.FieldErrors = append(e.FieldErrors, err)
+}
+
+func (e *FieldError) SetField(field string) {
+	e.Field = field
+}
+
+func NewValidationErrorWithField(field, message string) *FieldError {
+	return &FieldError{
+		Field: field,
+		Message: message,
+	}
+}
+
+func (e *FieldError) Flatten() *ValidationError {
+	me := &ValidationError{}
+	for _, v := range e.FieldErrors {
+		me.AddError(v)
+	}
+	return me
+}
+
+func NewValidationError(reason string, a ...interface{}) *FieldError {
+	return &FieldError{
+		Message: fmt.Sprintf(reason, a...),
+	}
 }
 
 type Validator interface {
@@ -110,6 +177,8 @@ func (sm StructMap) Unmarshal(ctx Context, parent *reflect.Value, partial interf
 		dstValue = dstValue.Elem()
 	}
 
+	errs := &FieldError{}
+
 	for _, field := range sm.Fields {
 		if field.ReadOnly {
 			continue
@@ -126,7 +195,9 @@ func (sm StructMap) Unmarshal(ctx Context, parent *reflect.Value, partial interf
 			if field.Optional {
 				continue
 			} else {
-				return NewValidationError("missing required field: %s", field.JSONFieldName)
+				err := NewValidationErrorWithField(field.JSONFieldName, "missing required field")
+				errs.AddError(err)
+				continue
 			}
 		}
 
@@ -148,11 +219,19 @@ func (sm StructMap) Unmarshal(ctx Context, parent *reflect.Value, partial interf
 		}
 
 		if err != nil {
-			if ve, ok := err.(*ValidationError); ok {
-				ve.PushKey(field.JSONFieldName)
+			switch e := err.(type) {
+			case *FieldError:
+				e.SetField(field.JSONFieldName)
+				errs.AddError(e)
+			default:
+				ve := NewValidationErrorWithField(field.JSONFieldName, e.Error())
+				errs.AddError(ve)
 			}
-			return err
 		}
+	}
+
+	if len(errs.FieldErrors) != 0 {
+		return errs
 	}
 
 	return nil
@@ -274,6 +353,8 @@ func (sm SliceMap) Unmarshal(ctx Context, parent *reflect.Value, partial interfa
 
 	elementType := dstValue.Type().Elem()
 
+	errs := &FieldError{}
+
 	for i, val := range data {
 		// Note: reflect.New() returns a pointer Value, so we have to take its
 		// Elem() before putting it to use
@@ -281,14 +362,26 @@ func (sm SliceMap) Unmarshal(ctx Context, parent *reflect.Value, partial interfa
 
 		err := sm.Contains.Unmarshal(ctx, &dstValue, val, dstElem)
 
+
 		if err != nil {
-			if ve, ok := err.(*ValidationError); ok {
-				ve.PushIndex(i)
+
+			switch e := err.(type) {
+			case *FieldError:
+				e.SetField(strconv.Itoa(i))
+				errs.AddError(e)
+			default:
+				// This should never happen but just to be safe
+				ve := NewValidationErrorWithField(strconv.Itoa(i), e.Error())
+				errs.AddError(ve)
 			}
-			return err
+			continue
 		}
 
 		result = reflect.Append(result, dstElem)
+	}
+
+	if len(errs.FieldErrors) != 0 {
+		return errs
 	}
 
 	// Note: this actually works with a reflect.Value of a slice, even though it
@@ -381,11 +474,13 @@ type MapMap struct {
 	Contains TypeMap
 }
 
-func (mm MapMap) Unmarshal(ctx Context, parent *reflect.Value, partial interface{}, dstValue reflect.Value) error {
+func (mm MapMap) Unmarshal(ctx Context, parent *reflect.Value, partial interface{}, dstValue reflect.Value) error { //check this
 	data, ok := partial.(map[string]interface{})
 	if !ok {
 		return NewValidationError("expected a map")
 	}
+
+	errs := &FieldError{}
 
 	// Maps default to nil, so we need to make() one
 	dstValue.Set(reflect.MakeMap(dstValue.Type()))
@@ -400,13 +495,22 @@ func (mm MapMap) Unmarshal(ctx Context, parent *reflect.Value, partial interface
 		err := mm.Contains.Unmarshal(ctx, &dstValue, val, dstElem)
 
 		if err != nil {
-			if ve, ok := err.(*ValidationError); ok {
-				ve.PushKey(key)
+			switch e := err.(type) {
+			case *FieldError:
+				e.SetField(key)
+				errs.AddError(e)
+			default:
+				// This should never happen but just to be safe
+				ne := NewValidationErrorWithField(key, e.Error())
+				errs.AddError(ne)
 			}
-			return err
+			continue
 		}
 
 		dstValue.SetMapIndex(reflect.ValueOf(key), dstElem)
+	}
+	if len(errs.FieldErrors) != 0 {
+		return errs
 	}
 
 	return nil
@@ -693,7 +797,14 @@ func (tm *TypeMapper) Unmarshal(ctx Context, data []byte, dest interface{}) erro
 			return e
 		}
 	}
-	return m.Unmarshal(ctx, nil, partial, reflect.ValueOf(dest).Elem())
+	err = m.Unmarshal(ctx, nil, partial, reflect.ValueOf(dest).Elem())
+	if err != nil {
+		if e, ok := err.(*FieldError); ok {
+			return e.Flatten()
+		}
+		return err
+	}
+	return nil
 }
 
 func (tm *TypeMapper) Marshal(ctx Context, src interface{}) ([]byte, error) {

--- a/jsonmap.go
+++ b/jsonmap.go
@@ -474,7 +474,7 @@ type MapMap struct {
 	Contains TypeMap
 }
 
-func (mm MapMap) Unmarshal(ctx Context, parent *reflect.Value, partial interface{}, dstValue reflect.Value) error { //check this
+func (mm MapMap) Unmarshal(ctx Context, parent *reflect.Value, partial interface{}, dstValue reflect.Value) error {
 	data, ok := partial.(map[string]interface{})
 	if !ok {
 		return NewValidationError("expected a map")

--- a/jsonmap.go
+++ b/jsonmap.go
@@ -30,7 +30,7 @@ func (e *FlattenedPathError) String() string {
 	return fmt.Sprintf("%s: %s\n", e.Path, e.Message)
 }
 
-func NewFlattedPathError(path, message string) *FlattenedPathError {
+func NewFlattenedPathError(path, message string) *FlattenedPathError {
 	return &FlattenedPathError{
 		Path: path,
 		Message: message,
@@ -55,7 +55,7 @@ func (e *ValidationError) AddError(err *FieldError, path ...string)  {
 	pointer := jsonpointer.NewJSONPointerFromTokens(&path)
 	if err.Message != "" {
 		jsonpath := pointer.String()
-		e.NestedErrors = append(e.NestedErrors, NewFlattedPathError(jsonpath, err.Message))
+		e.NestedErrors = append(e.NestedErrors, NewFlattenedPathError(jsonpath, err.Message))
 	}
 	for _, v := range err.FieldErrors {
 		e.AddError(v, path...)

--- a/jsonmap_test.go
+++ b/jsonmap_test.go
@@ -827,15 +827,24 @@ func TestValidateMultipleTypeMismatch(t *testing.T) {
 }
 
 func TestValidateMapOfInnerThing(t *testing.T) {
-	expected := `Validation Errors: 
+	expected1 := `Validation Errors: 
 /inner_thing_map/key1/an_int: too large, may not be larger than 10
 /inner_thing_map/key1/a_bool: not a boolean
 /inner_thing_map/key2/an_int: too large, may not be larger than 10
 /inner_thing_map/key2/a_bool: not a boolean
 `
+	expected2 := `Validation Errors: 
+/inner_thing_map/key2/an_int: too large, may not be larger than 10
+/inner_thing_map/key2/a_bool: not a boolean
+/inner_thing_map/key1/an_int: too large, may not be larger than 10
+/inner_thing_map/key1/a_bool: not a boolean
+`
 	v := &OuterInnerThingMap{}
 	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_thing_map":{"key1":{"an_int": 2048, "a_bool": 12.0}, "key2":{"an_int": 2048, "a_bool": 12.0}}}`), v)
-	require.EqualError(t, err, expected)
+
+	if err.Error() != expected1 && err.Error() != expected2 {
+		t.Fatal("Unexpected error message:", err.Error())
+	}
 }
 
 func TestValidateMapOfInnerThingFirstEntryValid(t *testing.T) {


### PR DESCRIPTION
Return multiple validation errors instead of the first error encountered. This will allow the user 
to resolve all (or most) of the issues with their input after a single failed attempt. The returned value is a struct containing a list with:
- a path: the string representation of the JSON pointer (following the [IETF RFC 6901 spec](https://www.rfc-editor.org/rfc/rfc6901.html)) 
- an error message
```
[
    {
        "path": "some_list/0/foo",
        "message": "too long, may not be more than 12 characters"
    },
    {
        "path": "some_list/0/bar",
        "message": "not an int"
    }
]
```


This change also includes switching to go modules to allow using a library for the JSON pointer construction 