### PR TITLE
Revert check to IsNil unless value is string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - 1.12.5
+  - 1.13
   - tip
 install:
   - go get -t ./...

--- a/jsonmap.go
+++ b/jsonmap.go
@@ -622,7 +622,7 @@ func (vt *variableType) Unmarshal(ctx Context, parent *reflect.Value, partial in
 }
 
 func (vt *variableType) Marshal(ctx Context, parent *reflect.Value, src reflect.Value) (json.Marshaler, error) {
-	if !src.IsValid() {
+	if src.Kind() != reflect.String && src.IsNil() {
 		return nullRawMessage, nil
 	}
 

--- a/jsonmap.go
+++ b/jsonmap.go
@@ -622,7 +622,7 @@ func (vt *variableType) Unmarshal(ctx Context, parent *reflect.Value, partial in
 }
 
 func (vt *variableType) Marshal(ctx Context, parent *reflect.Value, src reflect.Value) (json.Marshaler, error) {
-	if src.Kind() != reflect.String && src.IsNil() {
+	if src.IsZero() {
 		return nullRawMessage, nil
 	}
 

--- a/jsonmap_test.go
+++ b/jsonmap_test.go
@@ -1304,6 +1304,19 @@ func TestMarshalVariableTypeThingIntegerValid(t *testing.T) {
 	}
 }
 
+func TestMarshalVariableTypeThingIntegerValidZeroCase(t *testing.T) {
+	v := &OuterVariableThingInnerTypeOneOf{}
+	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_type":"these","inner_thing":0}`), v)
+
+	data, err := TestTypeMapper.Marshal(EmptyContext, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"inner_type":"these","inner_thing":0}` {
+		t.Fatal("Unexpected Marshal output:", string(data))
+	}
+}
+
 func TestMarshalBrokenVariableTypeThing(t *testing.T) {
 	defer func() {
 		r := recover()

--- a/jsonmap_test.go
+++ b/jsonmap_test.go
@@ -399,6 +399,9 @@ var OuterVariableThingWithOneOfInnerTypeMap = StructMap{
 			Contains: VariableType("InnerType", map[string]TypeMap{
 				"foo": InnerThingTypeMap,
 				"bar": OtherInnerThingTypeMap,
+				"these": PrimitiveMap(Integer(-5, 10)),
+				"are": PrimitiveMap(String(1, 5)),
+				"allowed": InnerThingTypeMap,
 			}),
 		},
 	},
@@ -1271,6 +1274,33 @@ func TestMarshalVariableTypeThing(t *testing.T) {
 		if string(data) != `{"inner_type":"bar","inner_thing":{"bar":"test"}}` {
 			t.Fatal("Unexpected Marshal output:", string(data))
 		}
+	}
+}
+
+
+func TestMarshalVariableTypeThingIntegerInvalid(t *testing.T) {
+	v := &OuterVariableThingInnerTypeOneOf{}
+	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_type":"these","inner_thing":15}`), v)
+
+	data, err := TestTypeMapper.Marshal(EmptyContext, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"inner_type":"these","inner_thing":null}` {
+		t.Fatal("Unexpected Marshal output:", string(data))
+	}
+}
+
+func TestMarshalVariableTypeThingIntegerValid(t *testing.T) {
+	v := &OuterVariableThingInnerTypeOneOf{}
+	err := TestTypeMapper.Unmarshal(EmptyContext, []byte(`{"inner_type":"these","inner_thing":5}`), v)
+
+	data, err := TestTypeMapper.Marshal(EmptyContext, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"inner_type":"these","inner_thing":5}` {
+		t.Fatal("Unexpected Marshal output:", string(data))
 	}
 }
 


### PR DESCRIPTION
Revert check changed in https://github.com/russellhaering/jsonmap/pull/5 to `IsNil` instead of `IsValid` for variableType marshalling unless the value is a string (calling IsNil on a string value type will panic)

The reason for changing this back is because `isValid` does not actually have the same behavior as `IsNil` - `isValid` will only return false if the value is the is the "zero Value" which only applies to "no value" rather than a `nil` value.