### PR TITLE
Mdcha/param

### DIFF
--- a/jsonmap_test.go
+++ b/jsonmap_test.go
@@ -1735,7 +1735,7 @@ func sliceRangeFactory(min, max int) func([]string) bool {
 
 var dogParamMap = QueryMap{
 	UnderlyingType: dogStruct{},
-	Parameters: []MappedParameter{
+	ParameterMaps: []ParameterMap{
 		{
 			StructFieldName: "Age",
 			ParameterName:   "age",
@@ -1799,7 +1799,7 @@ type requestFilter struct {
 
 var requestFilterMapping = QueryMap{
 	UnderlyingType: requestFilter{},
-	Parameters: []MappedParameter{
+	ParameterMaps: []ParameterMap{
 		{
 			StructFieldName: "UUID",
 			ParameterName:   "uuid",
@@ -1851,6 +1851,11 @@ func TestParamMapping(t *testing.T) {
 	err = dogParamMap.Encode(dog, newMap)
 	require.NoError(t, err)
 	require.EqualValues(t, urlQuery, newMap)
+
+	urlQuery, _ = url.ParseQuery("")
+	dog = dogStruct{}
+	err = dogParamMap.Decode(urlQuery, &dog)
+	require.NoError(t, err)
 
 	urlQuery, _ = url.ParseQuery(`count=38&uuid=00000000-0000-1000-9000-000000000000&search=foobar`)
 	filter := requestFilter{}

--- a/jsonmap_test.go
+++ b/jsonmap_test.go
@@ -1721,8 +1721,8 @@ type dogStruct struct {
 
 // Ostensibly non-testing versions of this would have error checking and such
 
-func intRangeFactory(min, max int) func(int) bool {
-	return func(n int) bool {
+func intRangeFactory(min, max int64) func(int64) bool {
+	return func(n int64) bool {
 		return min <= n && n <= max
 	}
 }
@@ -1740,7 +1740,7 @@ var dogParamMap = QueryMap{
 			StructFieldName: "Age",
 			ParameterName:   "age",
 			Mapper: IntQueryParameterMapper{
-				[]func(int) bool{
+				Validators: []func(int64) bool{
 					intRangeFactory(0, 100),
 				},
 			},
@@ -1814,7 +1814,7 @@ var requestFilterMapping = QueryMap{
 			StructFieldName: "Count",
 			ParameterName:   "count",
 			Mapper: IntQueryParameterMapper{
-				[]func(int) bool{
+				Validators: []func(int64) bool{
 					intRangeFactory(0, 500),
 				},
 			},

--- a/query.go
+++ b/query.go
@@ -1,0 +1,150 @@
+package jsonmap
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Map an individual value between its struct and query representations
+type QueryValueMapper interface {
+	Decode(string) (interface{}, error)
+	Encode(interface{}) (string, error)
+}
+
+// Map a slice of values between struct and query representation
+type QueryParameterMapper interface {
+	Decode([]string) (interface{}, error)
+	Encode(interface{}) ([]string, error)
+}
+
+// SingletonParameterMapper wraps a QueryValueMapper to expose a Query
+type SingletonParameterMapper struct {
+	ValueMapper  QueryValueMapper
+	IgnoreExtras bool
+}
+
+func (m *SingletonParameterMapper) Decode(in []string) (interface{}, error) {
+	switch len(in) {
+	case 0:
+		return nil, nil
+
+	case 1:
+		return m.ValueMapper.Decode(in[0])
+	default:
+		if m.IgnoreExtras {
+			return m.ValueMapper.Decode(in[0])
+		}
+
+		return nil, fmt.Errorf("received %d values, only expected 1", len(in))
+	}
+}
+
+func (m *SingletonParameterMapper) Encode(in interface{}) ([]string, error) {
+	out, err := m.ValueMapper.Encode(in)
+	if err != nil {
+		return nil, err
+	}
+
+	return []string{out}, nil
+}
+
+type RepeatedParameterMapper struct {
+	ValueMapper  QueryValueMapper
+	IgnoreExtras bool
+}
+
+func (m *RepeatedParameterMapper) Decode(in []string) (interface{}, error) {
+	out := make([]interface{}, len(in))
+	for i, val := range in {
+		decoded, err := m.ValueMapper.Decode(val)
+		if err != nil {
+			return nil, err
+		}
+
+		out[i] = decoded
+	}
+
+	return out, nil
+}
+
+func (m *RepeatedParameterMapper) Encode(in interface{}) ([]string, error) {
+	inSlice, ok := in.([]interface{})
+	if !ok {
+	}
+
+	out := make([]string{}, len(in))
+	out, err := m.ValueMapper.Encode(in)
+	if err != nil {
+		return nil, err
+	}
+
+	return []string{out}, nil
+}
+
+type StringQueryValueMapper struct {
+	Validator Validator
+}
+
+func (m *StringQueryValueMapper) Encode(in interface{}) (string, error) {
+	out, ok := in.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid type")
+	}
+
+	return out, nil
+}
+
+func (m *StringQueryValueMapper) Decode(in string) (interface{}, error) {
+	out, err := m.Validator.Validate(in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+
+
+type IntegerValueMapper struct {
+	Validator Validator
+}
+
+func (m *IntegerValueMapper) Encode(in interface{}) (string, error) {
+	out, ok := in.(int)
+	if !ok {
+		return "", fmt.Errorf("invalid type")
+	}
+
+	return strconv.Itoa(out), nil
+}
+
+func (m *IntegerValueMapper) Decode(in string) (interface{}, error) {
+	out, err := m.Validator.Validate(in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+type MappedParameter struct {
+	StructFieldName string
+	ParameterName   string
+	Mapper          QueryValueMapper
+}
+
+type QueryMap struct {
+	UnderlyingType interface{}
+	Parameters     []MappedParameter
+}
+
+var UserFilterMap = QueryMap{
+	UserFilter{},
+	[]MappedParameter{
+		{
+			StructFieldName: "Offset",
+			ParameterName:   "offset",
+			Mapper: SingletonParameterMapper{
+
+			},
+		},
+	},
+}

--- a/query.go
+++ b/query.go
@@ -2,6 +2,8 @@ package jsonmap
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
 	"reflect"
 	"strconv"
 )
@@ -18,10 +20,9 @@ type QueryMap struct {
 func (qm QueryMap) Encode(src interface{}, urlQuery map[string][]string) error {
 	srcVal := reflect.ValueOf(src)
 	for _, p := range qm.Parameters {
-		field := srcVal.FieldByName(p.StructFieldName)
-		strVal, err := p.Mapper.Encode(reflect.ValueOf(field))
+		strVal, err := p.Mapper.Encode(srcVal.FieldByName(p.StructFieldName))
 		if err != nil {
-			return errors.New("error in encoding struct")
+			return errors.New("error in encoding struct: " + err.Error())
 		}
 
 		urlQuery[p.ParameterName] = strVal
@@ -29,7 +30,49 @@ func (qm QueryMap) Encode(src interface{}, urlQuery map[string][]string) error {
 	return nil
 }
 
+// Taking a URL Query (or any string->[]string struct) and shoving it into the struct
+// as specified by qm.UnderlyingType
 func (qm QueryMap) Decode(urlQuery map[string][]string, dst interface{}) error {
+	if reflect.ValueOf(dst).Elem().Type() != reflect.TypeOf(qm.UnderlyingType) {
+		return fmt.Errorf("attempting to decode into mismatched struct: expected %s but got %s",
+			reflect.TypeOf(qm.UnderlyingType),
+			reflect.ValueOf(dst).Elem().Type(),
+		)
+	}
+
+	dstVal := reflect.ValueOf(dst).Elem()
+	for _, param := range qm.Parameters {
+		field := dstVal.FieldByName(param.StructFieldName)
+		fieldVal, err := param.Mapper.Decode(urlQuery[param.ParameterName])
+		if err != nil {
+			return fmt.Errorf("error ocurred while reading value: %s",
+				err.Error(),
+			)
+		}
+
+		field.Set(reflect.ValueOf(fieldVal))
+	}
+	return nil
+}
+
+// This ignores the case of parameter name in favor of the canonical format of
+// http.Header
+func (qm QueryMap) EncodeHeader(src interface{}, headers http.Header) error {
+	srcVal := reflect.ValueOf(src)
+	for _, p := range qm.Parameters {
+		field := srcVal.FieldByName(p.StructFieldName)
+		sliVal, err := p.Mapper.Encode(field)
+		if err != nil {
+			return errors.New("error in encoding struct: " + err.Error())
+		}
+
+		// Not using .Set() because it only allows strings and not slices
+		headers[http.CanonicalHeaderKey(p.ParameterName)] = sliVal
+	}
+	return nil
+}
+
+func (qm QueryMap) DecodeHeader(headers http.Header, dst interface{}) error {
 	if reflect.ValueOf(dst).Elem().Type() != reflect.TypeOf(qm.UnderlyingType) {
 		return errors.New("attempting to decode into the wrong struct")
 	}
@@ -37,7 +80,7 @@ func (qm QueryMap) Decode(urlQuery map[string][]string, dst interface{}) error {
 	dstVal := reflect.ValueOf(dst).Elem()
 	for _, param := range qm.Parameters {
 		field := dstVal.FieldByName(param.StructFieldName)
-		fieldVal, err := param.Mapper.Decode(urlQuery[param.ParameterName])
+		fieldVal, err := param.Mapper.Decode(headers[http.CanonicalHeaderKey(param.ParameterName)])
 		if err != nil {
 			return err
 		}
@@ -60,7 +103,7 @@ type MappedParameter struct {
 // These can be specified by their type (whichever struct the Parameter mapper will be,
 // and the restrictions defined on the type, defined by Validators slice below)
 type QueryParameterMapper interface {
-	Encode(interface{}) ([]string, error)
+	Encode(reflect.Value) ([]string, error)
 	Decode([]string) (interface{}, error)
 }
 
@@ -71,10 +114,10 @@ type StringQueryParameterMapper struct {
 
 func (sqpm StringQueryParameterMapper) Decode(src []string) (interface{}, error) {
 	if len(src) != 1 {
-		return nil, errors.New("expected only one value")
+		return nil, fmt.Errorf("expected one value, but got %d", len(src))
 	}
 
-	str := 	src[0]
+	str := src[0]
 	for _, v := range sqpm.Validators {
 		if !v(str) {
 			return nil, errors.New("a validation test failed")
@@ -83,13 +126,33 @@ func (sqpm StringQueryParameterMapper) Decode(src []string) (interface{}, error)
 	return str, nil
 }
 
-func (sqpm StringQueryParameterMapper) Encode(src interface{}) ([]string, error) {
-	s, ok := src.(string)
-	if !ok {
-		return nil, errors.New("improper type")
+func (sqpm StringQueryParameterMapper) Encode(src reflect.Value) ([]string, error) {
+	if src.Kind() != reflect.String {
+		return nil, fmt.Errorf("expected string but got: %s", src.Kind())
+	}
+	return []string{src.String()}, nil
+}
+
+// Does this need validators?
+type BoolQueryParameterMapper struct{}
+
+func (bqpm BoolQueryParameterMapper) Decode(src []string) (interface{}, error) {
+	if len(src) != 1 {
+		return nil, fmt.Errorf("expected one value, but got %d", len(src))
 	}
 
-	return []string{s}, nil
+	b, err := strconv.ParseBool(src[0])
+	if err != nil {
+		return nil, fmt.Errorf("could not parse into bool: %s", err.Error())
+	}
+	return b, nil
+}
+
+func (bqpm BoolQueryParameterMapper) Encode(src reflect.Value) ([]string, error) {
+	if src.Kind() != reflect.Bool {
+		return nil, fmt.Errorf("expected boolean but got: %s", src.Kind())
+	}
+	return []string{strconv.FormatBool(src.Bool())}, nil
 }
 
 type IntQueryParameterMapper struct {
@@ -98,12 +161,12 @@ type IntQueryParameterMapper struct {
 
 func (iqpm IntQueryParameterMapper) Decode(src []string) (interface{}, error) {
 	if len(src) != 1 {
-		return nil, errors.New("expected only one value")
+		return nil, fmt.Errorf("expected one value, but got %d", len(src))
 	}
 
 	num, err := strconv.Atoi(src[0])
 	if err != nil {
-		return nil, errors.New("param could not be converted to integer")
+		return nil, fmt.Errorf("param could not be converted to integer: %s", err.Error())
 	}
 
 	for _, v := range iqpm.Validators {
@@ -114,22 +177,22 @@ func (iqpm IntQueryParameterMapper) Decode(src []string) (interface{}, error) {
 	return num, nil
 }
 
-func (iqpm IntQueryParameterMapper) Encode(src interface{}) ([]string, error) {
-	n, ok := src.(int)
-	if !ok {
-		return nil, errors.New("improper type")
+func (iqpm IntQueryParameterMapper) Encode(src reflect.Value) ([]string, error) {
+	if src.Kind() != reflect.Int {
+		return nil, fmt.Errorf("expected int but got: %s", src.Kind())
 	}
-	return []string{strconv.Itoa(n)}, nil
+	return []string{strconv.FormatInt(src.Int(), 10)}, nil // Itoa doesn't take int64
 }
 
 type StrSliceQueryParameterMapper struct {
-	Validators []func([]string) bool
+	Validators                     []func([]string) bool
 	UnderlyingQueryParameterMapper QueryParameterMapper
 }
 
 func (sqpm StrSliceQueryParameterMapper) Decode(src []string) (interface{}, error) {
 	for _, val := range sqpm.Validators {
 		if !val(src) {
+			return nil, errors.New("A validation test failed")
 		}
 	}
 
@@ -140,22 +203,20 @@ func (sqpm StrSliceQueryParameterMapper) Decode(src []string) (interface{}, erro
 	for _, s := range src {
 		v, err := sqpm.UnderlyingQueryParameterMapper.Decode([]string{s})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("decoding a slice element failed: %s", err.Error())
 		}
 		retVal = append(retVal, v.(string))
 	}
 	return retVal, nil
 }
 
-func (sqpm StrSliceQueryParameterMapper) Encode(src interface{}) ([]string, error) {
-	slice, ok := src.([]interface{})
-	if !ok {
-		return nil, errors.New("improper type")
+func (sqpm StrSliceQueryParameterMapper) Encode(src reflect.Value) ([]string, error) {
+	if src.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("expected slice but got: %s", src.Kind())
 	}
-
 	var retSlice []string
-	for _, v := range slice {
-		s, err := sqpm.UnderlyingQueryParameterMapper.Encode(v)
+	for i := 0; i < src.Len(); i++ {
+		s, err := sqpm.UnderlyingQueryParameterMapper.Encode(src.Index(i))
 		if err != nil {
 			return nil, errors.New("error in encoding slice internals: " + err.Error())
 		}

--- a/query.go
+++ b/query.go
@@ -45,7 +45,9 @@ func (qm QueryMap) Decode(urlQuery map[string][]string, dst interface{}) error {
 		field := dstVal.FieldByName(param.StructFieldName)
 		fieldVal, err := param.Mapper.Decode(urlQuery[param.ParameterName])
 		if err != nil {
-			return fmt.Errorf("error ocurred while reading value: %s",
+			return fmt.Errorf("error ocurred while reading value (%s) into param %s: %s",
+				urlQuery[param.ParameterName],
+				param.StructFieldName,
 				err.Error(),
 			)
 		}


### PR DESCRIPTION
## What
Adding similar functionality for mapping between structs and `url.Values` (`map[string][]string`) without relying on struct tags.

## How
Each mapping above corresponds to an instance of `QueryMap` which will have individual mappings  (`ParameterMap`) between the appropriate `url.Values` value (`[]string`) and struct field, with support for validation checks as well (e.g. for string fields, min and max length, matching regex, etc).

## Why
Adding more usable validation checking for Filters, w/o relying on `gorilla/schema`