### PR TITLE
Adding more information to validator errors

### DIFF
--- a/jsonmap_test.go
+++ b/jsonmap_test.go
@@ -1740,8 +1740,8 @@ var dogParamMap = QueryMap{
 			StructFieldName: "Age",
 			ParameterName:   "age",
 			Mapper: IntQueryParameterMapper{
-				Validators: []func(int64) bool{
-					intRangeFactory(0, 100),
+				Validators: map[string]func(int64) bool{
+					"range": intRangeFactory(0, 100),
 				},
 			},
 		},
@@ -1749,9 +1749,9 @@ var dogParamMap = QueryMap{
 			StructFieldName: "Name",
 			ParameterName:   "name",
 			Mapper: StringQueryParameterMapper{
-				[]func(string) bool{
-					StringRangeValidator(1, 10),
-					StringRegexValidator(regexp.MustCompile(".*")),
+				map[string]func(string) bool{
+					"range": StringRangeValidator(1, 10),
+					"regex": StringRegexValidator(regexp.MustCompile(".*")),
 				},
 			},
 		},
@@ -1759,13 +1759,13 @@ var dogParamMap = QueryMap{
 			StructFieldName: "Owners",
 			ParameterName:   "owners",
 			Mapper: StrSliceQueryParameterMapper{
-				[]func([]string) bool{
-					sliceRangeFactory(0, 3),
+				map[string]func([]string) bool{
+					"range": sliceRangeFactory(0, 3),
 				},
 				StringQueryParameterMapper{
-					[]func(string) bool{
-						StringRangeValidator(1, 10),
-						StringRegexValidator(regexp.MustCompile("[a-z]")),
+					map[string]func(string) bool{
+						"range": StringRangeValidator(1, 10),
+						"regex": StringRegexValidator(regexp.MustCompile("[a-z]")),
 					},
 				},
 			},
@@ -1804,9 +1804,9 @@ var requestFilterMapping = QueryMap{
 			StructFieldName: "UUID",
 			ParameterName:   "uuid",
 			Mapper: StringQueryParameterMapper{
-				[]func(string) bool{
-					StringRegexValidator(uuidRegex),
-					utf8.ValidString,
+				map[string]func(string) bool{
+					"regex": StringRegexValidator(uuidRegex),
+					"valid": utf8.ValidString,
 				},
 			},
 		},
@@ -1814,8 +1814,8 @@ var requestFilterMapping = QueryMap{
 			StructFieldName: "Count",
 			ParameterName:   "count",
 			Mapper: IntQueryParameterMapper{
-				Validators: []func(int64) bool{
-					intRangeFactory(0, 500),
+				Validators: map[string]func(int64) bool{
+					"range": intRangeFactory(0, 500),
 				},
 			},
 		},
@@ -1824,8 +1824,8 @@ var requestFilterMapping = QueryMap{
 			StructFieldName: "Search",
 			ParameterName:   "search",
 			Mapper: StringQueryParameterMapper{
-				[]func(string) bool{
-					utf8.ValidString,
+				map[string]func(string) bool{
+					"valid": utf8.ValidString,
 				},
 			},
 		},

--- a/query.go
+++ b/query.go
@@ -159,7 +159,7 @@ type QueryParameterMapper interface {
 
 // Examples of mappers
 type StringQueryParameterMapper struct {
-	Validators []func(string) bool
+	Validators map[string]func(string) bool
 }
 
 func (sqpm StringQueryParameterMapper) Decode(src ...string) (interface{}, error) {
@@ -172,9 +172,9 @@ func (sqpm StringQueryParameterMapper) Decode(src ...string) (interface{}, error
 	}
 
 	str := src[0]
-	for _, v := range sqpm.Validators {
+	for name, v := range sqpm.Validators {
 		if !v(str) {
-			return nil, NewValidationError("a validation test failed")
+			return nil, NewValidationError("a validation test failed: " + name)
 		}
 	}
 
@@ -232,7 +232,7 @@ func (bqpm BoolQueryParameterMapper) Encode(src reflect.Value) ([]string, error)
 }
 
 type IntQueryParameterMapper struct {
-	Validators []func(int64) bool
+	Validators map[string]func(int64) bool
 	BitSize    int
 }
 
@@ -253,9 +253,9 @@ func (iqpm IntQueryParameterMapper) Decode(src ...string) (interface{}, error) {
 			)
 		}
 
-		for _, v := range iqpm.Validators {
+		for name, v := range iqpm.Validators {
 			if !v(num) {
-				return nil, NewValidationError("a validation test failed")
+				return nil, NewValidationError("a validation test failed: " + name)
 			}
 		}
 	}
@@ -284,7 +284,7 @@ func (iqpm IntQueryParameterMapper) Encode(src reflect.Value) ([]string, error) 
 }
 
 type UintQueryParameterMapper struct {
-	Validators []func(uint64) bool
+	Validators map[string]func(uint64) bool
 	BitSize    int
 }
 
@@ -303,9 +303,9 @@ func (uqpm UintQueryParameterMapper) Decode(src ...string) (interface{}, error) 
 			)
 		}
 
-		for _, v := range uqpm.Validators {
+		for name, v := range uqpm.Validators {
 			if !v(num) {
-				return nil, NewValidationError("a validation test failed")
+				return nil, NewValidationError("a validation test failed: " + name)
 			}
 		}
 	}
@@ -334,7 +334,7 @@ func (uqpm UintQueryParameterMapper) Encode(src reflect.Value) ([]string, error)
 }
 
 type TimeQueryParameterMapper struct {
-	Validators []func(time.Time) bool
+	Validators map[string]func(time.Time) bool
 }
 
 func (tqpm TimeQueryParameterMapper) Decode(src ...string) (interface{}, error) {
@@ -352,9 +352,9 @@ func (tqpm TimeQueryParameterMapper) Decode(src ...string) (interface{}, error) 
 		return nil, NewValidationError("param could not be marshalled to time.Time: %s", err.Error())
 	}
 
-	for _, v := range tqpm.Validators {
+	for name, v := range tqpm.Validators {
 		if !v(t) {
-			return nil, NewValidationError("a validation test failed")
+			return nil, NewValidationError("a validation test failed: " + name)
 		}
 	}
 	return t, nil
@@ -377,14 +377,14 @@ func (tqpm TimeQueryParameterMapper) Encode(src reflect.Value) ([]string, error)
 }
 
 type StrSliceQueryParameterMapper struct {
-	Validators                     []func([]string) bool
+	Validators                     map[string]func([]string) bool
 	UnderlyingQueryParameterMapper QueryParameterMapper
 }
 
 func (sqpm StrSliceQueryParameterMapper) Decode(src ...string) (interface{}, error) {
-	for _, val := range sqpm.Validators {
+	for name, val := range sqpm.Validators {
 		if !val(src) {
-			return nil, NewValidationError("A validation test failed")
+			return nil, NewValidationError("a validation test failed: " + name)
 		}
 	}
 


### PR DESCRIPTION
Currently using validators and failing hides information. This alters the Validators property to allow more information to be encoded.